### PR TITLE
use nalegrabr 0.26 (const-generics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## [0.4.1] Unrelease
+
+### Changed
+* bump nalgebra version to 0.26 (#19)
+
+
 ## [0.4.0] 08/04/2021
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 approx = "0.4"
-nalgebra = { version = "0.25", features = ["rand"] }
+nalgebra = { version = "0.26", features = ["rand"] }
 
 [lib]
 name = "eigenvalues"


### PR DESCRIPTION
Bump nalgebra version to use the new const-generics integration﻿
