### PR TITLE
Bump `approx` and `nalgebra` Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-approx = "0.4"
-nalgebra = { version = "0.26", features = ["rand"] }
+approx = "0.5"
+nalgebra = { version = "0.27", features = ["rand"] }
 
 [lib]
 name = "eigenvalues"


### PR DESCRIPTION
Both recently had updates, should be a harmless change.

Also, the released version of `eigenvalues` currently on crates.io requires `nalgebra < 0.25`, while the current is `0.27`, so it might be beneficial to make a release.

Cheers!